### PR TITLE
Add Bullet Points before each list item for legibility.

### DIFF
--- a/src/ui/components/items.rs
+++ b/src/ui/components/items.rs
@@ -13,15 +13,18 @@ pub struct ItemsComponent;
 
 impl ItemsComponent {
     /// Apply styling to a todo item based on its completion status
-    fn style_item(ui_item: &UIItem) -> Span<'_> {
+    fn style_item(ui_item: &UIItem) -> Line<'_> {
         let name = ui_item.item.name.clone();
 
-        if ui_item.item.is_done {
+        let bullet = Span::from("• ");
+        let content = if ui_item.item.is_done {
             // Strike through completed items
             Span::styled(name, Style::default().add_modifier(Modifier::CROSSED_OUT))
         } else {
             Span::from(name)
-        }
+        };
+
+        Line::from(vec![bullet, content])
     }
 
     /// Select next element in the list of to-do items


### PR DESCRIPTION
Each list item now contains a simple bullet point symbol ( • ) for clarity and legibility.

Extremely minor change to the code. 

Tested.

<img width="1718" height="1031" alt="Screenshot 2025-11-26 at 22 52 30" src="https://github.com/user-attachments/assets/65940698-cbf6-43df-a697-c7528ef5007e" />
